### PR TITLE
Medicine lister for visualization

### DIFF
--- a/medicine_lister.py
+++ b/medicine_lister.py
@@ -1,0 +1,33 @@
+import json
+
+with open ('mappable.json') as data_file:
+    data = json.load(data_file)
+
+med_list ={}
+#hashtable
+
+def update_med_list(meds, med_list, geotag, time):
+        for med in meds:
+            result = med_list.get(med)
+            if result:
+                result['count'] += 1
+                result['geo'].append(geotag)
+                result['time'].append(time)
+                med_list[med] = result
+            else:
+                med_list[med]={
+                    'count': 1,
+                    'geo': geotag,
+                    'time':[time]
+                }
+            return med_list
+
+def medicine_list(data, med_list):
+    for twit in data:
+                lista = update_med_list(twit['medicines'], med_list, twit['locations'],twit['tweet_date'])
+    return lista
+
+a = medicine_list(data, med_list)
+print(a)
+with open('Medicines.json','w') as outfile:
+    json.dump(a,outfile)


### PR DESCRIPTION
medicine_lister.py is a file that takes input a json like 'tweets-mappable.json' and outputs a medicine list with
 1: Total tweets count
 2: A list with all the locations for this medicine format 
 3: A list with all the timestamps from tweets

The list with locations its intended to be imported for mapping

The list with timestamps its intended to make a timeseries and detect possible outbreaks

There can be a disease list that relates with this medicine list